### PR TITLE
Add IndexedDB storage with JSON import/export

### DIFF
--- a/Message.html
+++ b/Message.html
@@ -151,6 +151,9 @@
 
   <div style="margin-top:40px;">
     <a href="history.html">▶ View past records</a>
+    <button onclick="exportData()">Export</button>
+    <input type="file" id="importInput" accept="application/json" style="display:none" onchange="importData(this.files[0])">
+    <button onclick="document.getElementById('importInput').click()">Import</button>
   </div>
 
   <!-- モーダル -->
@@ -179,6 +182,19 @@
     const MEMO_PREFIX = "memo-";
     const LAST_DATE_KEY = "last-open-date";
     const COMMENT_KEY = "comments";
+    const DB_NAME = "thoughtsDB";
+    const STORE_NAME = "thoughts";
+    const dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = e => {
+        const db = e.target.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
     let currentBubble = null;
     let currentId = null;
     const today = new Date().toISOString().slice(0, 10);
@@ -187,14 +203,60 @@
       return MEMO_PREFIX + date;
     }
 
+    function getThoughts(date = today) {
+      return dbPromise.then(db => new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly");
+        const req = tx.objectStore(STORE_NAME).get(date);
+        req.onsuccess = () => resolve(req.result || []);
+        req.onerror = () => reject(req.error);
+      }));
+    }
+
+    function setThoughts(date, data) {
+      return dbPromise.then(db => new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readwrite");
+        tx.objectStore(STORE_NAME).put(data, date);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      }));
+    }
+
+    function getAllThoughts() {
+      return dbPromise.then(db => new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly");
+        const store = tx.objectStore(STORE_NAME);
+        const data = {};
+        store.openCursor().onsuccess = e => {
+          const cursor = e.target.result;
+          if (cursor) {
+            data[cursor.key] = cursor.value;
+            cursor.continue();
+          } else {
+            resolve(data);
+          }
+        };
+        tx.onerror = () => reject(tx.error);
+      }));
+    }
+
+    async function migrateFromLocalStorage() {
+      const keys = Object.keys(localStorage).filter(k => k.startsWith(MEMO_PREFIX));
+      for (const key of keys) {
+        const date = key.slice(MEMO_PREFIX.length);
+        const value = JSON.parse(localStorage.getItem(key) || "[]");
+        await setThoughts(date, value);
+        localStorage.removeItem(key);
+      }
+    }
+
     // 保存
-    function saveBubbles() {
+    async function saveBubbles() {
       const data = Array.from(container.children).map(div => ({
         id: div.dataset.id,
         text: div.textContent,
         continued: div.dataset.continued === "true"
       }));
-      localStorage.setItem(getStorageKey(), JSON.stringify(data));
+      await setThoughts(today, data);
     }
 
     function saveComments(id, comments) {
@@ -204,8 +266,8 @@
     }
 
     // 読み込み
-    function loadBubbles(date = today) {
-      const data = JSON.parse(localStorage.getItem(getStorageKey(date)) || "[]");
+    async function loadBubbles(date = today) {
+      const data = await getThoughts(date);
       data.forEach(({ id, text, continued }) => createBubble(id, text, continued));
     }
 
@@ -340,16 +402,56 @@
       document.getElementById("carryoverModal").style.display = "none";
     }
 
-    // 初期化
-    const lastOpen = localStorage.getItem(LAST_DATE_KEY);
-    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
-    if (lastOpen !== today) {
-      const yData = JSON.parse(localStorage.getItem(getStorageKey(yesterday)) || "[]");
-      if (yData.length) showCarryover(yData);
+    async function exportData() {
+      const thoughts = await getAllThoughts();
+      const comments = JSON.parse(localStorage.getItem(COMMENT_KEY) || "{}");
+      const blob = new Blob([
+        JSON.stringify({ thoughts, comments }, null, 2)
+      ], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "thoughts.json";
+      a.click();
+      URL.revokeObjectURL(url);
     }
-    localStorage.setItem(LAST_DATE_KEY, today);
 
-    loadBubbles();
+    function importData(file) {
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = async () => {
+        try {
+          const data = JSON.parse(reader.result);
+          if (data.thoughts) {
+            for (const [date, arr] of Object.entries(data.thoughts)) {
+              await setThoughts(date, arr);
+            }
+          }
+          if (data.comments) {
+            localStorage.setItem(COMMENT_KEY, JSON.stringify(data.comments));
+          }
+          location.reload();
+        } catch (e) {
+          alert("Import failed: " + e.message);
+        }
+      };
+      reader.readAsText(file);
+    }
+
+    // 初期化
+    (async function () {
+      await migrateFromLocalStorage();
+      const lastOpen = localStorage.getItem(LAST_DATE_KEY);
+      const yesterday = new Date(Date.now() - 86400000)
+        .toISOString()
+        .slice(0, 10);
+      if (lastOpen !== today) {
+        const yData = await getThoughts(yesterday);
+        if (yData.length) showCarryover(yData);
+      }
+      localStorage.setItem(LAST_DATE_KEY, today);
+      await loadBubbles();
+    })();
   </script>
 </body>
 </html>

--- a/history.html
+++ b/history.html
@@ -32,34 +32,79 @@
   <h2>過去の思考</h2>
   <div id="history"></div>
 
-  <script>
-    const MEMO_PREFIX = "memo-";
+    <script>
+      const DB_NAME = "thoughtsDB";
+      const STORE_NAME = "thoughts";
+      const MEMO_PREFIX = "memo-";
 
-    function renderHistory() {
-      const historyDiv = document.getElementById("history");
-      historyDiv.innerHTML = "";
-      const keys = Object.keys(localStorage)
-        .filter(k => k.startsWith(MEMO_PREFIX))
-        .sort()
-        .reverse();
-      keys.forEach(key => {
-        const date = key.slice(MEMO_PREFIX.length);
-        const items = JSON.parse(localStorage.getItem(key) || "[]");
-        if (!items.length) return;
-        const header = document.createElement("div");
-        header.className = "dayHeader";
-        header.textContent = date;
-        historyDiv.appendChild(header);
-        items.forEach(({ text }) => {
-          const div = document.createElement("div");
-          div.className = "historyBubble";
-          div.textContent = text;
-          historyDiv.appendChild(div);
-        });
+      const dbPromise = new Promise((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, 1);
+        req.onupgradeneeded = e => {
+          const db = e.target.result;
+          if (!db.objectStoreNames.contains(STORE_NAME)) {
+            db.createObjectStore(STORE_NAME);
+          }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
       });
-    }
 
-    document.addEventListener("DOMContentLoaded", renderHistory);
-  </script>
+      function getAllThoughts() {
+        return dbPromise.then(db => new Promise((resolve, reject) => {
+          const tx = db.transaction(STORE_NAME, "readonly");
+          const store = tx.objectStore(STORE_NAME);
+          const data = {};
+          store.openCursor().onsuccess = e => {
+            const cursor = e.target.result;
+            if (cursor) {
+              data[cursor.key] = cursor.value;
+              cursor.continue();
+            } else {
+              resolve(data);
+            }
+          };
+          tx.onerror = () => reject(tx.error);
+        }));
+      }
+
+      async function migrateFromLocalStorage() {
+        const keys = Object.keys(localStorage).filter(k => k.startsWith(MEMO_PREFIX));
+        for (const key of keys) {
+          const date = key.slice(MEMO_PREFIX.length);
+          const value = JSON.parse(localStorage.getItem(key) || "[]");
+          const db = await dbPromise;
+          const tx = db.transaction(STORE_NAME, "readwrite");
+          tx.objectStore(STORE_NAME).put(value, date);
+          await new Promise(r => (tx.oncomplete = r));
+          localStorage.removeItem(key);
+        }
+      }
+
+      async function renderHistory() {
+        await migrateFromLocalStorage();
+        const historyDiv = document.getElementById("history");
+        historyDiv.innerHTML = "";
+        const all = await getAllThoughts();
+        Object.keys(all)
+          .sort()
+          .reverse()
+          .forEach(date => {
+            const items = all[date];
+            if (!items.length) return;
+            const header = document.createElement("div");
+            header.className = "dayHeader";
+            header.textContent = date;
+            historyDiv.appendChild(header);
+            items.forEach(({ text }) => {
+              const div = document.createElement("div");
+              div.className = "historyBubble";
+              div.textContent = text;
+              historyDiv.appendChild(div);
+            });
+          });
+      }
+
+      document.addEventListener("DOMContentLoaded", renderHistory);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move thought storage from `localStorage` to an IndexedDB database `thoughtsDB`
- support exporting all thoughts/comments to a JSON file
- allow importing thoughts from a JSON file
- migrate any old `localStorage` data on first load
- update history page to read from IndexedDB

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684990ff57f483219b5352df9bc7bc61